### PR TITLE
Remove autocapitalize on clear text passwords

### DIFF
--- a/src/components/steps/Mqtt.vue
+++ b/src/components/steps/Mqtt.vue
@@ -39,7 +39,7 @@
         <label class="label" for="mqtt_password">MQTT password</label>
         <p class="control is-grouped">
           <!-- v-model does not support dynamic :type -->
-          <input v-if="passwordClearText" type="text" class="input" v-model.trim="password" id="mqtt_password" placeholder="Password" />
+          <input v-if="passwordClearText" type="text" class="input" autocapitalize="none" v-model.trim="password" id="mqtt_password" placeholder="Password" />
           <input v-else type="password" class="input" v-model.trim="password" id="mqtt_password" placeholder="Password" />
           <label class="checkbox">
             <input type="checkbox" v-model="passwordClearText" /> Show password

--- a/src/components/steps/Wifi.vue
+++ b/src/components/steps/Wifi.vue
@@ -30,7 +30,7 @@
         <label class="label" for="wifi_password">Wi-Fi password</label>
         <p class="control is-grouped">
           <!-- v-model does not support dynamic :type -->
-          <input v-if="passwordClearText" type="text" class="input" v-model.trim="password" id="wifi_password" placeholder="Password" maxLength="64" />
+          <input v-if="passwordClearText" type="text" class="input" autocapitalize="none" v-model.trim="password" id="wifi_password" placeholder="Password" maxLength="64" />
           <input v-else type="password" class="input" v-model.trim="password" id="wifi_password" placeholder="Password" maxLength="64" />
           <label class="checkbox">
             <input type="checkbox" v-model="passwordClearText" /> Show password


### PR DESCRIPTION
Passwords for mqtt and wifi was auto capitalized (at least on Android) when the show password button was checked before typing. 